### PR TITLE
kanban: add a minimum height for droppable area of project boards

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2843,6 +2843,7 @@ tbody.commit-list {
 
 .board-column > .cards {
     margin: 0 !important;
+    min-height: 35px;
 
     .card .meta > a.milestone {
         color: #999999;


### PR DESCRIPTION
This ensures there's actually an area to drop cards into, in case
one is bootstrapping an otherwise empty project board. The minimum height
is just a little bit smaller than a standard card.