### PR TITLE
adds some css to cards and board-cards

### DIFF
--- a/web_src/less/_repository.less
+++ b/web_src/less/_repository.less
@@ -2843,7 +2843,9 @@ tbody.commit-list {
 
 .board-column > .cards {
     margin: 0 !important;
-    min-height: 35px;
+    display: list-item;
+    height: 92%;
+    padding: 5px;
 
     .card .meta > a.milestone {
         color: #999999;
@@ -2869,6 +2871,10 @@ tbody.commit-list {
 
 .board-card {
     margin: 3px !important;
+    width: 100%;
+    background-color: white;
+    border-radius: 5px;
+    cursor: pointer;
 }
 
 .board-card .header {


### PR DESCRIPTION
.board-column > .cards
1. Fix for the droppable area to extend to the end of the column in order to make it easier for the user to drag stuff on it.
2. Display the cards as list.
3. Added some padding to fix horizontal overflow.
4. Removed the min-height added by @kevans91 because the above changes made it irrelevant.

.board-card
1. Expanded the board-card area in order for the user to be able to grab it.
2. Added color to the board card.
3. Added border radius to add some pizzazz.
4. Added a pointer cursor to the card in order to inform the user that it is draggable.

More info about this pull request can be found [here](https://github.com/go-gitea/gitea/pull/8346#issuecomment-623176683)